### PR TITLE
[Bugfix] Fix Sonarcloud integration

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,21 +8,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2.3.4
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Run tests
       run: |
         python -m pip install --upgrade pip
         sh test.sh
+    - name: Get PR author
+      id: get_author
+      run: echo ::set-output name=AUTHOR::${{ github.event.pull_request.user.login }}
     - name: SonarCloud Scan
-      if: ${{ matrix.python-version == '3.9'}}
+      if: ${{ matrix.python-version == '3.10' && steps.get_author.outputs.AUTHOR == 'rogervila' }}
       uses: sonarsource/sonarcloud-github-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.SONAR_GITHUB_TOKEN }}
@@ -31,6 +34,7 @@ jobs:
         args: >
           -Dsonar.organization=rogervila-github
           -Dsonar.projectKey=rogervila_python_carbon
+          -Dsonar.python.version=3.10
           -Dsonar.python.coverage.reportPaths=coverage.xml
           -Dsonar.sources=.
           -Dsonar.exclusions=tests/**


### PR DESCRIPTION
Github secrets are not accessible from forks.

Since Sonarcloud needs to access them, the scan will run only for PR made by me. 